### PR TITLE
Fix the white seam when rendering imagery

### DIFF
--- a/Assets/Materials/Types/GltfStandardPBR_Common.azsli
+++ b/Assets/Materials/Types/GltfStandardPBR_Common.azsli
@@ -57,8 +57,8 @@ ShaderResourceGroup MaterialSrg : SRG_PerMaterial
 
     Sampler m_sampler
     {
-        AddressU = Wrap;
-        AddressV = Wrap;
+        AddressU = Clamp;
+        AddressV = Clamp;
         MinFilter = Linear;
         MagFilter = Linear;
         MipFilter = Linear;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+### ? - ?
+
+##### Fixes :wrench:
+
+- Change texture's addressU and addressV from wrap to clamp to fix the white seam when rendering imagery.
+
 ### v1.0.0 - 2022-02-15 - Initial Release
 
 ##### Features :tada:


### PR DESCRIPTION
It's possible that the imagery UV is out of range and so the sampler is wrapped back again to create the seam. Changing it to Clamp seems to fix the issue

Fixes #23